### PR TITLE
Properly use the devel series for the base tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 DPKG_ARCH := $(shell dpkg --print-architecture)
-LTS=impish
-BASE := $(LTS)-base-$(DPKG_ARCH).tar.gz
-URL := http://cdimage.ubuntu.com/ubuntu-base/$(LTS)/daily/current/$(BASE)
+#LTS=jj
+#BASE := $(LTS)-base-$(DPKG_ARCH).tar.gz
+#URL := http://cdimage.ubuntu.com/ubuntu-base/$(LTS)/daily/current/$(BASE)
+# Temporarily until JJ is open and released
+DEVEL=impish
+BASE := $(DEVEL)-base-$(DPKG_ARCH).tar.gz
+URL := http://cdimage.ubuntu.com/ubuntu-base/daily/current/$(BASE)
 
 # dir that contans the filesystem that must be checked
 TESTDIR ?= "prime/"


### PR DESCRIPTION
The devel tarballs have a different path than tarballs from already released series. This is why originally, in my previous PR, there was the whole DEVEL instead of LTS magic.
We could just change the url, but I think this way it is much more clear that this is completely temporary.