### PR TITLE
Use build-base: core22 for LP to recognize Impish as the build platform.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
   The base snap based on the Ubuntu 2X.YY release.
 confinement: strict
 type: base
-build-base: core20
+build-base: core22
 grade: devel
 
 parts:


### PR DESCRIPTION
This seems to be the final bit required to get the new core22 snap building.

Since in Launchpad it's not possible to select 'Impish' as the series, and we need to build on impish because we no longer build daily tarballs of hirsute, we need to rely on LP's ability to guess the series from snapcraft.yaml. It seems LP does that guessing per `build-base:`. Now that LP recognizes core22 as a base (albeit still a devel one), we can switch to using it as the 'build-base' and make the builders acknowledge that we need to use Impish.

Ran a test build via a separate snap build recipe and it seems to build successfully:
https://launchpad.net/~sil2100/snap-core22/+snap/core22