### PR TITLE
Add bootchart configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ stop when the `snapd.seeded.service` stops). The bootchart will be saved
 in the `ubuntu-save` partition, under `log/boot<N>/`, being `<N>` the
 boot number since bootcharts were enabled. If a chart has been collected
 by the initramfs, it will be also saved in that folder.
+
+**TODO** In the future, we would want `systemd-bootchart` to be started
+only from the initramfs and have just one bootchart per boot. However,
+this is currently not possible as `systemd-bootchart` needs some changes
+so it can survive the switch root between initramfs and data
+partition. With those changes, we could also have `systemd-bootchart` as
+init process so we get an even more accurate picture.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ worked as expected.
 The `.test` scripts will be run after building with snapcraft or when
 doing a manual "make test" in the source tree.
 
+# Bootchart
+
+It is possible to enable bootcharts by adding
+`systemd.wants=systemd-bootchart.service` to the kernel command
+line. The sample collector will run until the system is seeded (it will
+stop when the `snapd.seeded.service` stops). The bootchart will be saved
+in the `ubuntu-save` partition, under `log/boot<N>/`, being `<N>` the
+boot number since bootcharts were enabled. If a chart has been collected
+by the initramfs, it will be also saved in that folder (this will happen
+if we have also added `rd.systemd.wants=systemd-bootchart.service` to
+the kernel command line).

--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ doing a manual "make test" in the source tree.
 # Bootchart
 
 It is possible to enable bootcharts by adding
-`systemd.wants=systemd-bootchart.service` to the kernel command
+`core.bootchart` to the kernel command
 line. The sample collector will run until the system is seeded (it will
 stop when the `snapd.seeded.service` stops). The bootchart will be saved
 in the `ubuntu-save` partition, under `log/boot<N>/`, being `<N>` the
 boot number since bootcharts were enabled. If a chart has been collected
-by the initramfs, it will be also saved in that folder (this will happen
-if we have also added `rd.systemd.wants=systemd-bootchart.service` to
-the kernel command line).
+by the initramfs, it will be also saved in that folder.

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ doing a manual "make test" in the source tree.
 
 # Bootchart
 
-It is possible to enable bootcharts by adding
-`core.bootchart` to the kernel command
-line. The sample collector will run until the system is seeded (it will
-stop when the `snapd.seeded.service` stops). The bootchart will be saved
-in the `ubuntu-save` partition, under `log/boot<N>/`, being `<N>` the
-boot number since bootcharts were enabled. If a chart has been collected
-by the initramfs, it will be also saved in that folder.
+It is possible to enable bootcharts by adding `core.bootchart` to the
+kernel command line. The sample collector will run until the system is
+seeded (it will stop when the `snapd.seeded.service` stops). The
+bootchart will be saved in the `ubuntu-data` partition, under
+`/var/log/debug/boot<N>/`, `<N>` being the boot number since
+bootcharts were enabled. If a chart has been collected by the
+initramfs, it will be also saved in that folder.
 
 **TODO** In the future, we would want `systemd-bootchart` to be started
 only from the initramfs and have just one bootchart per boot. However,

--- a/hook-tests/024-configure-bootchart.test
+++ b/hook-tests/024-configure-bootchart.test
@@ -1,0 +1,6 @@
+#!/bin/sh -ex
+
+test -f usr/lib/systemd/bootchart.conf.d/ubuntu-core.conf
+test -f lib/systemd/system/systemd-bootchart.service
+test -x lib/systemd/systemd-bootchart-poststop.sh
+test -f lib/systemd/system/stop-systemd-bootchart.service

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -45,6 +45,7 @@ apt update
 apt dist-upgrade -y
 apt install --no-install-recommends -y \
     systemd \
+    systemd-bootchart \
     systemd-sysv \
     finalrd \
     libnss-extrausers \

--- a/hooks/024-configure-bootchart.chroot
+++ b/hooks/024-configure-bootchart.chroot
@@ -1,0 +1,71 @@
+#! /bin/sh -ex
+
+# Rewrite unit that came with the systemd-bootchart package
+
+cat << 'EOF' > /lib/systemd/system/systemd-bootchart.service
+[Unit]
+Description=Boot Process Profiler
+Documentation=man:systemd-bootchart.service(1) man:bootchart.conf(5)
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=shutdown.target
+Requires=stop-systemd-bootchart.service
+
+[Service]
+ExecStartPre=/usr/bin/mkdir -p /run/log/base
+ExecStart=/lib/systemd/systemd-bootchart -r
+KillSignal=SIGHUP
+ExecStopPost=/lib/systemd/systemd-bootchart-poststop.sh
+
+[Install]
+WantedBy=sysinit.target
+EOF
+
+# Creating these files could go to static folder, but it seems cleaner to have
+# everything together in one place.
+
+mkdir -p /usr/lib/systemd/bootchart.conf.d
+cat << 'EOF' > /usr/lib/systemd/bootchart.conf.d/ubuntu-core.conf
+[Bootchart]
+Samples=36000
+Frequency=20
+Relative=yes
+Filter=no
+# Memory usage produces a bad overlay in the svg
+#PlotMemoryUsage=yes
+Cmdline=yes
+Output=/run/log/base
+EOF
+
+cat << 'EOF' > /lib/systemd/systemd-bootchart-poststop.sh
+#!/bin/sh -ex
+
+save_d=/run/mnt/ubuntu-save/log
+last_d=$(find $save_d/ -type d -name boot\* | sort | tail -n1)
+if [ -z "$last_d" ]; then last_d=0; fi
+next_d=$save_d/boot$((${last_d##*boot} + 1))
+mkdir -p $next_d
+mv /run/log/base/*.svg $next_d
+
+initrd_f=$(find /run/log -maxdepth 1 -name \*.svg -printf "%f" -quit)
+if [ -n "$initrd_f" ]; then
+    mv /run/log/"$initrd_f" $next_d/initrd-"$initrd_f"
+fi
+EOF
+
+cat << 'EOF' > /lib/systemd/system/stop-systemd-bootchart.service
+[Unit]
+Description=Unit to stop systemd-bootchart
+After=snapd.seeded.service
+Requisite=snapd.seeded.service
+ConditionKernelCommandLine=snapd_recovery_mode=run
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl stop systemd-bootchart.service
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+chmod +x /lib/systemd/systemd-bootchart-poststop.sh

--- a/hooks/024-configure-bootchart.chroot
+++ b/hooks/024-configure-bootchart.chroot
@@ -43,7 +43,7 @@ EOF
 cat << 'EOF' > /lib/systemd/systemd-bootchart-poststop.sh
 #!/bin/sh -ex
 
-save_d=/run/mnt/ubuntu-save/log
+save_d=/run/mnt/data/system-data/var/log/debug
 last_d=$(find $save_d/ -type d -name boot\* | sort | tail -n1)
 if [ -z "$last_d" ]; then last_d=0; fi
 next_d=$save_d/boot$((${last_d##*boot} + 1))

--- a/hooks/024-configure-bootchart.chroot
+++ b/hooks/024-configure-bootchart.chroot
@@ -10,6 +10,7 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 Before=shutdown.target
 Requires=stop-systemd-bootchart.service
+ConditionKernelCommandLine=core.bootchart
 
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /run/log/base
@@ -20,6 +21,8 @@ ExecStopPost=/lib/systemd/systemd-bootchart-poststop.sh
 [Install]
 WantedBy=sysinit.target
 EOF
+
+systemctl enable systemd-bootchart.service
 
 # Creating these files could go to static folder, but it seems cleaner to have
 # everything together in one place.


### PR DESCRIPTION
Add configuration files so it is possible to get a bootchart on
boot. The systemd-bootchart.service will not be enabled by default,
but it will be possible to enable it from kernel command
line (systemd.wants=systemd-bootchart.service) if we want it to run on
first boot.