### PR TITLE
Generate dpkg.yaml for OSS compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,11 @@ install:
 		rm -f $(DESTDIR)/tmp/$$(basename $$f); \
 	done;
 
-	# only generate manifest file for lp build
+	# only generate manifest and dpkg.yaml file for lp build
 	if [ -e /build/core20 ]; then \
 		echo $$f; \
 		/bin/cp $(DESTDIR)/usr/share/snappy/dpkg.list /build/core20/core20-$$(date +%Y%m%d%H%M)_$(DPKG_ARCH).manifest; \
+		/bin/cp $(DESTDIR)/usr/share/snappy/dpkg.yaml /build/core20/core20-$$(date +%Y%m%d%H%M)_$(DPKG_ARCH).dpkg.yaml; \
 	fi;
 
 .PHONY: check

--- a/hook-tests/001-extra-packages.test
+++ b/hook-tests/001-extra-packages.test
@@ -65,7 +65,6 @@ libdebconfclient0:amd64
 libdevmapper1.02.1:amd64
 libext2fs2:amd64
 libfdisk1:amd64
-libffi8ubuntu1:amd64
 libgcc-s1:amd64
 libgcrypt20:amd64
 libgmp10:amd64

--- a/hook-tests/600-no-debian.chroot
+++ b/hook-tests/600-no-debian.chroot
@@ -13,7 +13,7 @@ then
 else
   echo "Error! PPA section of dpkg.yaml not as expected."
   echo "If that is intentional, please update the ppa_section content in the"
-  echo "test file: core18/hook-tests/600-no-debian.test."
+  echo "test file: core22/hook-tests/600-no-debian.test."
   exit 1
 fi
 
@@ -25,7 +25,7 @@ do
     echo "Couldn't find package: $pkg in $FILE."
     echo "If that is intentional, please update the packages_section "
     echo "content in the "
-    echo "test file: core18/hook-tests/600-no-debian.test."
+    echo "test file: core22/hook-tests/600-no-debian.test."
     exit 1
   fi
 done

--- a/hook-tests/600-no-debian.chroot
+++ b/hook-tests/600-no-debian.chroot
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# test for hook that creates dpkg.yaml used for OSS compliance
+
+#first check if file exists
+FILE=usr/share/snappy/dpkg.yaml
+test -e $FILE
+
+#second check the PPA section of dpkg.yaml
+if grep -Fq "canonical-foundations/ubuntu/ubuntu-image" $FILE
+then
+  echo "Content of PPA section is as expected in dpkg.yaml."
+else
+  echo "Error! PPA section of dpkg.yaml not as expected."
+  echo "If that is intentional, please update the ppa_section content in the"
+  echo "test file: core18/hook-tests/600-no-debian.test."
+  exit 1
+fi
+
+# check for some of the core packages
+for pkg in adduser apt bash coreutils dpkg fdisk gcc-10-base hostname iptables libc6 lsb-base mount netbase openssl passwd python3 ubuntu-keyring
+do
+  if !(grep -Fq "$pkg" $FILE); then
+    echo "Error! Packages section of dpkg.yaml not as expected."
+    echo "Couldn't find package: $pkg in $FILE."
+    echo "If that is intentional, please update the packages_section "
+    echo "content in the "
+    echo "test file: core18/hook-tests/600-no-debian.test."
+    exit 1
+  fi
+done
+echo "Content of Packages section in dpkg.yaml file is as expected."

--- a/hooks/600-no-debian.chroot
+++ b/hooks/600-no-debian.chroot
@@ -10,6 +10,25 @@ echo "I: Removing the debian legacy"
 install -m755 -d usr/share/snappy
 dpkg -l > usr/share/snappy/dpkg.list
 
+# generate dpkg.yaml needed for OSS compliance
+{
+  # fill in ppa information in yaml file
+  printf 'package-repositories:\n'
+  find /etc/apt/ -name \*.list | while IFS= read -r APT; do
+    grep -o "^deb http://ppa.launchpad.net/[a-z0-9\.\+\-]\+/[a-z0-9\.\+\-]\+/[a-z0-9\.\+\-]\+" "$APT" | while read -r ENTRY ; do
+      USER=$(echo "$ENTRY" | cut -d/ -f4)
+      PPA=$(echo "$ENTRY" | cut -d/ -f5)
+      DISTRO=$(echo "$ENTRY" | cut -d/ -f6)
+      printf -- '- type: apt\n'
+      echo '  ppa: '"$USER/$DISTRO/$PPA"
+    done
+  done
+
+  # fill in yaml section with all installed packages
+  printf 'packages:\n'
+  dpkg-query -W --showformat='- ${binary:Package}=${Version}\n'
+} > /usr/share/snappy/dpkg.yaml
+
 # dpkg-deb and dpkg purposefully left behind
 dpkg --purge --force-depends apt libapt-pkg5.0 debconf
 


### PR DESCRIPTION
I'm not actually able to build this snap as I was for core, core18 or core20.
I'm getting a multipass error: " launch failed: Unable to find an image matching "core22". An error occurred with the instance when trying to launch with 'multipass': returned exit code 2. Ensure that 'multipass' is setup correctly and try again."
I'm using snapcraft version 5.0 and multipass  1.7.1.
It would be ideal if I could build locally to see if the list of packages in the unit test is  correct for core22.