### PR TITLE
fix libffi version for impish

### DIFF
--- a/hook-tests/001-extra-packages.test
+++ b/hook-tests/001-extra-packages.test
@@ -65,7 +65,7 @@ libdebconfclient0:amd64
 libdevmapper1.02.1:amd64
 libext2fs2:amd64
 libfdisk1:amd64
-libffi8ubuntu1:amd64
+libffi8:amd64
 libgcc-s1:amd64
 libgcrypt20:amd64
 libgmp10:amd64


### PR DESCRIPTION
in impish, libffi package name is simply libffi8
fixing this to let lp build correctly