### PR TITLE
Fix provided group IDs in core22

### DIFF
--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -212,7 +212,7 @@ pkcs11:x:115:
 tss:x:116:
 input:x:107:
 render:x:117:
-sgx:x:113:
+sgx:x:119:
 _ssh:x:118:
 EOF
 cp /etc/group /etc/group.orig # We make a copy for a later sanity-compare

--- a/hooks/990-ensure-uids-gids.chroot
+++ b/hooks/990-ensure-uids-gids.chroot
@@ -28,6 +28,10 @@ echo "Ensure no user 107 (ex-docker)"
 cut -d: -f3 /etc/passwd | grep -q 107
 rc=$?; [ "$rc" = "0" ] && MISMATCH=1
 
+echo "Ensure no group 113 (ex-docker)"
+cut -d: -f3 /etc/group | grep -q 113
+rc=$?; [ "$rc" = "0" ] && MISMATCH=1
+
 if [ -n "$MISMATCH" ]; then
     echo "There were changes to the password database."
     echo "This usually means something wrong happened during the execution of hooks."


### PR DESCRIPTION
Now that I understand the situation, switch back to guarding against a GID 113 and move the sgx to a new free GID. Big thanks to mvo for catching this mistake!