### PR TITLE
Switch to jammy, and remove some core20 references.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ DPKG_ARCH := $(shell dpkg --print-architecture)
 #LTS=jj
 #BASE := $(LTS)-base-$(DPKG_ARCH).tar.gz
 #URL := http://cdimage.ubuntu.com/ubuntu-base/$(LTS)/daily/current/$(BASE)
-# Temporarily until JJ is open and released
-DEVEL=impish
+# Temporarily until JJ is released
+DEVEL=jammy
 BASE := $(DEVEL)-base-$(DPKG_ARCH).tar.gz
 URL := http://cdimage.ubuntu.com/ubuntu-base/daily/current/$(BASE)
 
@@ -56,9 +56,9 @@ install:
 	done;
 
 	# only generate manifest file for lp build
-	if [ -e /build/core20 ]; then \
+	if [ -e /build/core22 ]; then \
 		echo $$f; \
-		/bin/cp $(DESTDIR)/usr/share/snappy/dpkg.list /build/core20/core20-$$(date +%Y%m%d%H%M)_$(DPKG_ARCH).manifest; \
+		/bin/cp $(DESTDIR)/usr/share/snappy/dpkg.list /build/core22/core22-$$(date +%Y%m%d%H%M)_$(DPKG_ARCH).manifest; \
 	fi;
 
 .PHONY: check

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,9 +1,9 @@
 name: core22
 # version: "22"
 adopt-info: bootstrap
-summary: Runtime environment based on Ubuntu 2X.YY
+summary: Runtime environment based on Ubuntu 22.04
 description: |
-  The base snap based on the Ubuntu 2X.YY release.
+  The base snap based on the Ubuntu 22.04 release.
 confinement: strict
 type: base
 build-base: core22
@@ -82,7 +82,7 @@ parts:
       # as there seems to be an issue with the current snapd on impish, causing
       # core-dumps of the mksquashfs call (via `snap pack`).
       - snapd/latest/edge
-    # XXX: Dirty hacks to enable building core20 on non-focal systems.
+    # XXX: Dirty hacks to enable building core22 on non-jammy systems.
     # Without these overrides both the PATH and LD_LIBRARY_PATH contain paths
     # in the part's install directory which binaries can be incompatible with
     # the ones running on our system.  We don't need those while running stage


### PR DESCRIPTION
This is mostly just a formality, since we already build using the current 'devel' tarball (as jammy is not out yet) - so we're pulling in the jammy tarball now anyway.

Note for the future: we might want to revisit some of the core20 hacks that are present in snapcraft.yaml and see if those are still relevant.